### PR TITLE
Fix go tests by making them compatible with course db schema

### DIFF
--- a/cli/data/data.go
+++ b/cli/data/data.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Course struct {
-	Name     string
-	Year     int
-	Term     string
-	Subject  string
-	Number   int
+	Name    string
+	Year    int
+	Term    string
+	Subject string
+	Number  int
 }
 
 func GetCourseByNum(subject string, num int) (Course, error) {

--- a/cli/data/data.go
+++ b/cli/data/data.go
@@ -12,13 +12,12 @@ type Course struct {
 	Name     string
 	Year     int
 	Term     string
-	YearTerm string
 	Subject  string
 	Number   int
 }
 
 func GetCourseByNum(subject string, num int) (Course, error) {
-	db, err := sql.Open("sqlite3", "../../python/gpa_dataset.db")
+	db, err := sql.Open("sqlite3", "../../python/course.db")
 
 	if subject == "" {
 		return Course{}, errors.New("empty subject")
@@ -32,7 +31,7 @@ func GetCourseByNum(subject string, num int) (Course, error) {
 		fmt.Println(err)
 	}
 	var course Course
-	if err := db.QueryRow("SELECT * FROM courses WHERE Subject=@subject AND Number=@num", subject, num).Scan(&course.Year, &course.Term, &course.YearTerm, &course.Subject, &course.Number, &course.Name); err != nil {
+	if err := db.QueryRow("SELECT year, term, subject, number, name FROM Course WHERE subject=@subject AND number=@num", subject, num).Scan(&course.Year, &course.Term, &course.Subject, &course.Number, &course.Name); err != nil {
 		fmt.Println(err)
 	}
 	db.Close()
@@ -40,7 +39,7 @@ func GetCourseByNum(subject string, num int) (Course, error) {
 }
 
 func GetCourseByName(name string) (Course, error) {
-	db, err := sql.Open("sqlite3", "../../python/gpa_dataset.db")
+	db, err := sql.Open("sqlite3", "../../python/course.db")
 
 	if name == "" {
 		return Course{}, errors.New("empty course name")
@@ -50,7 +49,7 @@ func GetCourseByName(name string) (Course, error) {
 		fmt.Println(err)
 	}
 	var course Course
-	if err := db.QueryRow("SELECT * FROM courses WHERE `Course Title`=@name", name).Scan(&course.Year, &course.Term, &course.YearTerm, &course.Subject, &course.Number, &course.Name); err != nil {
+	if err := db.QueryRow("SELECT year, term, subject, number, name FROM Course WHERE `name`=@name", name).Scan(&course.Year, &course.Term, &course.Subject, &course.Number, &course.Name); err != nil {
 		fmt.Println(err)
 	}
 	db.Close()

--- a/cli/tests/db_test.go
+++ b/cli/tests/db_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestCanOpenDB(t *testing.T) {
-	db, err := sql.Open("sqlite3", "../../python/gpa_dataset.db")
+	db, _ := sql.Open("sqlite3", "../../python/course.db")
+	err := db.Ping()
 
 	if err != nil {
 		t.Errorf("could not open database")
@@ -20,8 +21,8 @@ func TestCanOpenDB(t *testing.T) {
 }
 
 func TestCourseDataIntegrity(t *testing.T) {
-	db, _ := sql.Open("sqlite3", "../../python/gpa_dataset.db")
-	courses, err := db.Query("SELECT * FROM courses")
+	db, _ := sql.Open("sqlite3", "../../python/course.db")
+	courses, err := db.Query("SELECT * FROM Course")
 	if err != nil {
 		t.Errorf("couldn't query courses")
 	}
@@ -32,54 +33,54 @@ func TestCourseDataIntegrity(t *testing.T) {
 		t.Errorf("error parsing columns")
 	}
 
-	if len(cols) != 6 {
+	if len(cols) != 23 {
 		t.Errorf("incorrect number of columns")
 	}
 	db.Close()
 }
 
 func TestGetCourseByNum(t *testing.T) {
-	course, err := data.GetCourseByNum("CS", 225)
+	course, err := data.GetCourseByNum("ACE", 161)
 
 	if err != nil {
 		t.Errorf("error when getting course")
 	}
-	if course.Name != "Data Structures" {
+	if course.Name != "Microcomputer Applications" {
 		t.Errorf("incorrect name")
 	}
-	if course.Year != 2021 {
+	if course.Year != 2022 {
 		t.Errorf("incorrect year")
 	}
-	if course.Term != "Fall" {
+	if course.Term != "Winter" {
 		t.Errorf("incorrect term")
 	}
-	if course.Subject != "CS" {
+	if course.Subject != "ACE" {
 		t.Errorf("incorrect subject")
 	}
-	if course.Number != 225 {
+	if course.Number != 161 {
 		t.Errorf("incorrect name")
 	}
 }
 
 func TestGetCourseByName(t *testing.T) {
-	course, err := data.GetCourseByName("Data Structures")
+	course, err := data.GetCourseByName("Microcomputer Applications")
 
 	if err != nil {
 		t.Errorf("error when getting course")
 	}
-	if course.Name != "Data Structures" {
+	if course.Name != "Microcomputer Applications" {
 		t.Errorf("incorrect name")
 	}
-	if course.Year != 2021 {
+	if course.Year != 2022 {
 		t.Errorf("incorrect year")
 	}
-	if course.Term != "Fall" {
+	if course.Term != "Winter" {
 		t.Errorf("incorrect term")
 	}
-	if course.Subject != "CS" {
+	if course.Subject != "ACE" {
 		t.Errorf("incorrect subject")
 	}
-	if course.Number != 225 {
+	if course.Number != 161 {
 		t.Errorf("incorrect name")
 	}
 }

--- a/cli/tests/db_test.go
+++ b/cli/tests/db_test.go
@@ -12,7 +12,6 @@ import (
 func TestCanOpenDB(t *testing.T) {
 	db, _ := sql.Open("sqlite3", "../../python/course.db")
 	err := db.Ping()
-
 	if err != nil {
 		t.Errorf("could not open database")
 	}
@@ -28,7 +27,6 @@ func TestCourseDataIntegrity(t *testing.T) {
 	}
 
 	cols, err := courses.Columns()
-
 	if err != nil {
 		t.Errorf("error parsing columns")
 	}
@@ -41,7 +39,6 @@ func TestCourseDataIntegrity(t *testing.T) {
 
 func TestGetCourseByNum(t *testing.T) {
 	course, err := data.GetCourseByNum("ACE", 161)
-
 	if err != nil {
 		t.Errorf("error when getting course")
 	}
@@ -64,7 +61,6 @@ func TestGetCourseByNum(t *testing.T) {
 
 func TestGetCourseByName(t *testing.T) {
 	course, err := data.GetCourseByName("Microcomputer Applications")
-
 	if err != nil {
 		t.Errorf("error when getting course")
 	}


### PR DESCRIPTION
Go tests should pass once this PR and my other one (which adds course.db) are merged.

Also fixed the test “TestCanOpenDB.” Now it won't pass if the data source is invalid/nonexistent (see https://pkg.go.dev/database/sql#Open).