### PR TITLE
update getters to use gorm and changed usage

### DIFF
--- a/cli/cmd/course.go
+++ b/cli/cmd/course.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -15,21 +14,17 @@ import (
 	"github.com/CS222-UIUC/course-project-group-10.git/data"
 )
 
-func getCourse(args []string) (data.Course, error) {
+func getCourse(args []string) ([]data.Course, error) {
 	if len(args) == 0 {
 	} else if len(args) == 1 { // argument is probably a course name
-		courses, err := data.GetCoursesByName(args[0], 1)
-		return courses[0], err
+		course, err := data.GetCourses(map[string]interface{}{"name": args[0]}, "LIMIT 1")
+		return course, err
 	} else if len(args) == 2 { // argument is probably a course subject and number
-		number, err := strconv.Atoi(args[1])
-		if err != nil {
-			return data.Course{}, errors.New("given course number is not a number")
-		}
-		courses, err := data.GetCoursesByNum(args[0], number, 1)
-		return courses[0], err
+		course, err := data.GetCourses(map[string]interface{}{"subject": args[0], "number": args[1]}, "LIMIT 1")
+		return course, err
 	}
 
-	return data.Course{}, errors.New("malformed arguments")
+	return []data.Course{}, errors.New("malformed arguments")
 }
 
 func printCourse(cmd *cobra.Command, args []string) {
@@ -41,7 +36,7 @@ func printCourse(cmd *cobra.Command, args []string) {
 		fmt.Println("course [course name] to get a course by name (eg. course \"Data Structures\")")
 		fmt.Println("course [subject] [number] to get a course by number (eg. course CS 225)")
 	} else {
-		fmt.Println(course)
+		data.CoursesToString(course)
 	}
 }
 

--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -33,7 +33,7 @@ func historyFunc(cmd *cobra.Command, args []string) {
 	}
 
 	// initalize argsMap used by the getters
-	argsMap := map[string]interface{}{"subject": course[0].Subject, "number": course[0].Number,}
+	argsMap := map[string]interface{}{"subject": course[0].Subject, "number": course[0].Number}
 
 	// print depending on flags
 	if (latest || oldest) && num != -1 {
@@ -43,14 +43,14 @@ func historyFunc(cmd *cobra.Command, args []string) {
 		if oldest {
 			// if sorting by oldest, reverse the slice
 			fmt.Println("Sorting by oldest")
-			courses, err = data.GetCourses(argsMap, "ORDER BY year DESC" + " LIMIT " + strconv.Itoa(num))
+			courses, err = data.GetCourses(argsMap, "ORDER BY year DESC"+" LIMIT "+strconv.Itoa(num))
 			if err != nil {
 				fmt.Println(err.Error())
 				fmt.Println("could not get course")
 			}
 		} else if latest || num != -1 {
 			// just fetch the correct number of courses
-			courses, err = data.GetCourses(argsMap, "LIMIT "+ strconv.Itoa(num))
+			courses, err = data.GetCourses(argsMap, "LIMIT "+strconv.Itoa(num))
 			if err != nil {
 				fmt.Println(err.Error())
 				fmt.Println("could not get course")
@@ -85,12 +85,12 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	//var course string
+	// var course string
 	var latest bool
 	var oldest bool
 	var num int
 
-	//historyCmd.Flags().StringVarP(&course, "course", "c", "", "Course to find")
+	// historyCmd.Flags().StringVarP(&course, "course", "c", "", "Course to find")
 	historyCmd.Flags().BoolVarP(&latest, "latest", "l", false, "Sort by latest first")
 	historyCmd.Flags().BoolVarP(&oldest, "oldest", "o", false, "Sort by oldest first")
 	historyCmd.Flags().IntVarP(&num, "number", "n", 8, "Number of results to list")

--- a/cli/cmd/history.go
+++ b/cli/cmd/history.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/CS222-UIUC/course-project-group-10.git/data"
@@ -16,77 +15,59 @@ import (
 
 func historyFunc(cmd *cobra.Command, args []string) {
 	// read in course argument
-	var course []data.Course
-	var err error
-	if len(args) == 0 {
-		log.Fatal("No arguments passed. Command usage: either a subject and number (ex CS 225) or a course name (ex \"Data Structures\")")
-	} else if len(args) == 1 { // argument is probably a course name
-		course, err = data.GetCoursesByName(args[0], 1)
-	} else if len(args) == 2 { // argument is probably a course subject and number
-		number, atoi_err := strconv.Atoi(args[1])
-		if atoi_err != nil {
-			log.Fatal("Not a valid course number.")
-		}
-		course, err = data.GetCoursesByNum(args[0], number, 1)
-	}
+	course, err := getCourse(args)
 	if err != nil {
-		fmt.Println(err.Error())
-		log.Fatal("Error getting course")
+		fmt.Println("Error getting course:", err)
+		fmt.Println("Usage:")
+		fmt.Println("course [course name] to get a course by name (eg. course \"Data Structures\")")
+		fmt.Println("course [subject] [number] to get a course by number (eg. course CS 225)")
+		return
 	}
 
 	// read in flags
-	latest, err := cmd.Flags().GetBool("latest")
-	if err != nil {
-		fmt.Println("flag would not be read", err)
-	}
-	oldest, err := cmd.Flags().GetBool("oldest")
-	if err != nil {
-		fmt.Println("flag would not be read", err)
-	}
+	latest, _ := cmd.Flags().GetBool("latest")
+	oldest, _ := cmd.Flags().GetBool("oldest")
 	num, err := cmd.Flags().GetInt("number")
 	if err != nil {
 		fmt.Println("flag would not be read", err)
 	}
 
+	// initalize argsMap used by the getters
+	argsMap := map[string]interface{}{"subject": course[0].Subject, "number": course[0].Number,}
+
 	// print depending on flags
-	if latest || oldest || num != -1 {
+	if (latest || oldest) && num != -1 {
 		// get slice of all courses with specified number
 		var courses []data.Course
 		var err error
 		if oldest {
 			// if sorting by oldest, reverse the slice
 			fmt.Println("Sorting by oldest")
-			// reverse courses slice
-			courses, err = data.GetCoursesByNum(course[0].Subject, course[0].Number, 100)
+			courses, err = data.GetCourses(argsMap, "ORDER BY year DESC" + " LIMIT " + strconv.Itoa(num))
 			if err != nil {
 				fmt.Println(err.Error())
+				fmt.Println("could not get course")
 			}
-			var reversed []data.Course
-			for i := len(courses) - 1; i >= len(courses)-num; i-- {
-				reversed = append(reversed, courses[i])
-			}
-			courses = reversed
 		} else if latest || num != -1 {
-			courses, err = data.GetCoursesByNum(course[0].Subject, course[0].Number, num)
+			// just fetch the correct number of courses
+			courses, err = data.GetCourses(argsMap, "LIMIT "+ strconv.Itoa(num))
 			if err != nil {
 				fmt.Println(err.Error())
+				fmt.Println("could not get course")
 			}
 		}
-		// if no --number flag was passed, set it to the length of the courses slice
-		// print the sorted results
-		for i := 0; i < len(courses); i++ {
-			output := data.CourseToString(courses[i])
-			fmt.Println(output)
-			for i := 0; i < len(output); i++ {
-				fmt.Print("-")
-			}
-			fmt.Println()
-		}
+		// print courses
+		fmt.Println(data.CoursesToString(courses))
 
 	} else {
 		// by default, just print latest
 		fmt.Println("Latest Offering: ")
-		fmt.Println(data.CourseToString(course[0]))
+		courses, err := data.GetCourses(argsMap, "LIMIT 1")
+		if err != nil {
+			fmt.Println(err)
+			fmt.Println("could not get course")
+		}
+		fmt.Println(data.CoursesToString(courses))
 	}
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	//set up database global variable
+	// set up database global variable
 	var err error
 	data.DB, err = gorm.Open(sqlite.Open("../python/course.db"), &gorm.Config{})
 	if err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,9 +4,23 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package main
 
 import (
+	"fmt"
+
 	"github.com/CS222-UIUC/course-project-group-10.git/cli/cmd"
+	"github.com/CS222-UIUC/course-project-group-10.git/data"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func main() {
+	//set up database global variable
+	var err error
+	data.DB, err = gorm.Open(sqlite.Open("../python/course.db"), &gorm.Config{})
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	cmd.Execute()
+	sqlDb, _ := (*data.DB).DB()
+	sqlDb.Close()
 }

--- a/data/data.go
+++ b/data/data.go
@@ -3,91 +3,179 @@ package data
 import (
 	"database/sql"
 	"errors"
+
+	//"errors"
+
 	"strconv"
 
 	_ "github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
 )
 
+// global db variable, opened and closed in main
+var DB *gorm.DB
+
+type Tabler interface {
+	TableName() string
+}
+
+// TableName overrides the table name used by gorm
+func (Course) TableName() string {
+	return "course"
+}
+func (Section) TableName() string {
+	return "section"
+}
+func (Meeting) TableName() string {
+	return "meeting"
+}
+func (GPAEntry) TableName() string {
+	return "GPA_Entry"
+}
+func (Instructor) TableName() string {
+	return "instructor"
+}
+
 type Course struct {
-	Name    string
-	Year    int
-	Term    string
-	Subject string
-	Number  int
+	Name          string         `db:"name"`
+	Year          int            `db:"year"`
+	Term          string         `db:"term"`
+	Subject       string         `db:"subject"`
+	Number        int            `db:"number"`
+	Description   string         `db:"description"`
+	CreditHours   string         `db:"credit_hours"`
+	AC            int            `db:"advanced_comp"`
+	NW            int            `db:"non_western"`
+	US            int            `db:"us_minority"`
+	W             int            `db:"western"`
+	HP            int            `db:"hist_phil"`
+	LA            int            `db:"lit_arts"`
+	LS            int            `db:"life_sci"`
+	PS            int            `db:"phys_sci"`
+	QR1           int            `db:"quant_res_1"`
+	QR2           int            `db:"quant_res_2"`
+	BS            int            `db:"behav_sci"`
+	SS            int            `db:"social_sci"`
+	SectionInfo   sql.NullString `db:"section_info"`
+	DegreeAttribs sql.NullString `db:"degree_attribs"`
+	ScheduleInfo  sql.NullString `db:"schedule_info"`
 }
 
-func GetCoursesByNum(subject string, num int, limit int) ([]Course, error) {
-	db, err := sql.Open("sqlite3", "../python/course.db")
+type Section struct {
+	Id               int            `db:"id"`
+	CourseId         int            `db:"course_id"`
+	CRN              int            `db:"crn"`
+	SectionNumber    string         `db:"section_number"`
+	StatusCode       string         `db:"status_code"`
+	SectStatusCode   string         `db:"sect_status_code"`
+	PartOfTerm       string         `db:"part_of_term"`
+	EnrollmentStatus string         `db:"enrollment_status"`
+	StartDate        string         `db:"start_date"`
+	EndDate          string         `db:"end_date"`
+	Description      sql.NullString `db:"description"`
+}
 
-	if subject == "" {
-		return []Course{}, errors.New("empty subject")
-	}
+type Meeting struct {
+	Type       string         `db:"type"`
+	StartTime  string         `db:"start_time"`
+	EndTime    sql.NullString `db:"end_time"`
+	DaysOfWeek sql.NullString `db:"days_of_week"`
+	RoomNum    sql.NullString `db:"room_num"`
+	Id         string         `db:"id"`
+	SectionId  string         `db:"section_id"`
+}
 
-	if num < 0 || num > 799 {
-		return []Course{}, errors.New("number out of range")
-	}
+type GPAEntry struct {
+	Id        string `db:"id"`
+	SchedType string `db:"sched_type"`
+	APlus     int    `db:"a_plus"`
+	A         int    `db:"a"`
+	AMinus    int    `db:"a_minus"`
+	BPlus     int    `db:"b_plus"`
+	B         int    `db:"b"`
+	BMinus    int    `db:"b_minus"`
+	CPlus     int    `db:"c_plus"`
+	C         int    `db:"c"`
+	CMinus    int    `db:"c_minus"`
+	DPlus     int    `db:"d_plus"`
+	D         int    `db:"d"`
+	DMinus    int    `db:"d_minus"`
+	F         int    `db:"f"`
+	W         int    `db:"w"`
+}
 
-	if subject == "" {
-		return []Course{}, errors.New("empty subject")
-	}
+type Instructor struct {
+	Id        string `db:"id"`
+	FirstName string `db:"first_name"`
+	LastName  string `db:"last_name"`
+}
 
-	if num < 0 || num > 799 {
-		return []Course{}, errors.New("number out of range")
-	}
+// getters take in two arguments:
+// example: GetCourses(map[string]interface{}{"subject":"ACE", "number":161,}, "LIMIT 10") will find the first 10 courses where subject=ACE and number=161
 
-	if err != nil {
-		return []Course{}, errors.New(err.Error())
-	}
+// "argsMap" is a map[string]interface{} from column name to value to search for
+// to create a map, do mapName := map[string]interface{}{"columnName1": val1, "columnName2": val2,}
+// columnName must be a string, but val can be any type
+// make sure val is the same type of the column as listed in the DB documentation
+
+// "clauses" is a string with optional additional statements you want to add to the end of a query
+// for example, if you want to sort by descending and only return 6 rows, pass
+// clauses := string{"ORDER BY year DESC LIMIT 6"}
+// if you want no additional statements, just pass an empty string
+func GetCourses(argsMap map[string]interface{}, clauses string) ([]Course, error) {
 	var courses []Course
-	rows, err := db.Query("SELECT year, term, subject, number, name FROM Course WHERE subject=@subject AND number=@num LIMIT @limit", subject, num, limit)
-	if err != nil {
-		return courses, err
-	}
-	for rows.Next() {
-		var course Course
-		if err := rows.Scan(&course.Year, &course.Term, &course.Subject, &course.Number, &course.Name); err != nil {
-			return courses, err
+	//queryDB := DB.Session(&gorm.Session{})
+	// this initializes the DB
+	queryDB := DB
+
+	// build the query as a string, adding each key in the argsMap to the AND statement
+	// queryString looks like "columnName = @mapKey" where columnName is the name of the column we want to search and mapKey is the key to the value we want it to be
+	// if we built our map correctly, these should always be the same
+	queryString := ""
+	for key, val := range argsMap {
+		// do error checking of fields that aren't ints
+		if key != "number" && key != "year" {
+			if val == "" {
+				return courses, errors.New("field cannot be empty")
+			}
 		}
-		courses = append(courses, course)
+		// do error checking for numbers
+		if key == "number" {
+			if val.(int) < 0 || val.(int) > 799 {
+				return courses, errors.New("number out of range")
+			}
+		}
+		queryString += key + " = @" + key + " AND "
 	}
-	rows.Close()
-	db.Close()
+	// remove the trailing " AND ""
+	if len(argsMap) > 0 {
+		queryString = queryString[0 : len(queryString)-5]
+	}
+	// append any additional clauses to the end of query
+	queryString += " " + clauses
+	//fmt.Println(queryString)
+
+	// see section about Named Arguments to see how passing a map[string]interface{} works:
+	// https://gorm.io/docs/sql_builder.html#Raw-SQL
+	// this code uses the second example snippet
+
+	// .Find(&courses) takes the preceding statement, executes it, and puts it into courses slice
+	// nothing is returned
+	queryDB.Where(queryString, argsMap).Find(&courses)
 	return courses, nil
 }
 
-func GetCoursesByName(name string, limit int) ([]Course, error) {
-	db, err := sql.Open("sqlite3", "../python/course.db")
-
-	if name == "" {
-		return []Course{}, errors.New("empty course name")
-	}
-
-	if name == "" {
-		return []Course{}, errors.New("empty course name")
-	}
-
-	if err != nil {
-		return []Course{}, errors.New(err.Error())
-	}
-
-	var courses []Course
-	rows, err := db.Query("SELECT year, term, subject, number, name FROM Course WHERE `name`=@name LIMIT @limit", name, limit)
-	if err != nil {
-		return courses, err
-	}
-	for rows.Next() {
-		var course Course
-		if err := rows.Scan(&course.Year, &course.Term, &course.Subject, &course.Number, &course.Name); err != nil {
-			return courses, err
+func CoursesToString(courses []Course) string {
+	var output string
+	for _, course := range courses {
+		curr_line := "| " + course.Term + " " + strconv.Itoa(course.Year) + "\t| " + course.Subject + " " + strconv.Itoa(course.Number) + " | " + course.Name + "\n"
+		output += curr_line
+		for i := 0; i < len(curr_line); i++ {
+			output += "-"
 		}
-		courses = append(courses, course)
+		output += "\n"
 	}
-	rows.Close()
-	db.Close()
-	return courses, nil
-}
-
-func CourseToString(course Course) string {
-	var output string = "| " + course.Term + " " + strconv.Itoa(course.Year) + "\t| " + course.Subject + " " + strconv.Itoa(course.Number) + " | " + course.Name
 	return output
 }
+
+//func GetInstructor

--- a/data/data.go
+++ b/data/data.go
@@ -3,10 +3,9 @@ package data
 import (
 	"database/sql"
 	"errors"
+	"strconv"
 
 	//"errors"
-
-	"strconv"
 
 	_ "github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
@@ -23,15 +22,19 @@ type Tabler interface {
 func (Course) TableName() string {
 	return "course"
 }
+
 func (Section) TableName() string {
 	return "section"
 }
+
 func (Meeting) TableName() string {
 	return "meeting"
 }
+
 func (GPAEntry) TableName() string {
 	return "GPA_Entry"
 }
+
 func (Instructor) TableName() string {
 	return "instructor"
 }
@@ -144,7 +147,7 @@ func GetCourses(argsMap map[string]interface{}, clauses string) ([]Course, error
 			}
 		}
 		// if error checks are successful, add the statement to the query
-		// queryString looks something like "columnName1 = @mapKey1 AND columnName2 = @mapKey2" 
+		// queryString looks something like "columnName1 = @mapKey1 AND columnName2 = @mapKey2"
 		// where columnName is the name of the column we want to search and mapKey is the key to the value we want it to be
 		// this is equivalent to the statement "SELECT * FROM course WHERE columnName1 = argsMap[mapKey1] AND columnName2 = argsMap[mapKey2]"
 		queryString += key + " = @" + key + " AND "
@@ -155,7 +158,7 @@ func GetCourses(argsMap map[string]interface{}, clauses string) ([]Course, error
 	}
 	// append any additional clauses to the end of query
 	queryString += " " + clauses
-	//fmt.Println(queryString)
+	// fmt.Println(queryString)
 
 	// see section about Named Arguments to see how passing a map[string]interface{} works:
 	// https://gorm.io/docs/sql_builder.html#Raw-SQL

--- a/data/data.go
+++ b/data/data.go
@@ -3,6 +3,7 @@ package data
 import (
 	"database/sql"
 	"errors"
+	"reflect"
 	"strconv"
 
 	//"errors"
@@ -142,7 +143,13 @@ func GetCourses(argsMap map[string]interface{}, clauses string) ([]Course, error
 		}
 		// do error checking for numbers
 		if key == "number" {
-			if val.(int) < 0 || val.(int) > 799 {
+			var value int
+			if reflect.TypeOf(val).String() == "string" {
+				value, _ = strconv.Atoi(val.(string))
+			} else {
+				value = val.(int)
+			}
+			if value < 0 || value > 799 {
 				return courses, errors.New("number out of range")
 			}
 		}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -63,3 +63,59 @@ func TestValidNumber(t *testing.T) {
 		t.Errorf("should not be allowed to have non-three-digit number (too big)")
 	}
 }
+
+func TestGetCourseByNum(t *testing.T) {
+	course, err := GetCourses(map[string]interface{}{"subject": "ACE", "number": 161}, "LIMIT 1")
+	if err != nil {
+		t.Errorf("error when getting course")
+		fmt.Println(err)
+	}
+	if course[0].Name != "Microcomputer Applications" {
+		t.Errorf("incorrect name")
+	}
+	if course[0].Year != 2022 {
+		t.Errorf("incorrect year")
+	}
+	if course[0].Term != "Winter" {
+		t.Errorf("incorrect term")
+	}
+	if course[0].Subject != "ACE" {
+		t.Errorf("incorrect subject")
+	}
+	if course[0].Number != 161 {
+		t.Errorf("incorrect name")
+	}
+}
+
+func TestGetCourseByName(t *testing.T) {
+	course, err := GetCourses(map[string]interface{}{"name": "Microcomputer Applications"}, "LIMIT 1")
+	if err != nil {
+		t.Errorf("error when getting course")
+		fmt.Println(err)
+	}
+	if course[0].Name != "Microcomputer Applications" {
+		t.Errorf("incorrect name")
+	}
+	if course[0].Year != 2022 {
+		t.Errorf("incorrect year")
+	}
+	if course[0].Term != "Winter" {
+		t.Errorf("incorrect term")
+	}
+	if course[0].Subject != "ACE" {
+		t.Errorf("incorrect subject")
+	}
+	if course[0].Number != 161 {
+		t.Errorf("incorrect name")
+	}
+}
+
+func TestGetSections(t *testing.T) {
+	section, err := GetSections(map[string]interface{}{"crn": 10105},"")
+	if (err != nil) {
+		t.Errorf("error when getting section")
+	}
+	if section[0].StartDate != "2021-12-20Z" {
+		t.Errorf("incorrext start date")
+	}
+}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -3,42 +3,61 @@ package data
 import (
 	"fmt"
 	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestValidName(t *testing.T) {
-	_, err := GetCoursesByName("Microcomputer Applications", 1)
+	var err error
+	DB, err = gorm.Open(sqlite.Open("../python/course.db"), &gorm.Config{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	_, err = GetCourses(map[string]interface{}{"name": "Microcomputer Applications"}, "LIMIT 1")
 	if err != nil {
 		t.Errorf("error when getting valid course")
 		fmt.Println(err)
 	}
 
-	_, err = GetCoursesByName("", 1)
+	_, err = GetCourses(map[string]interface{}{"name": ""}, "LIMIT 1")
 
 	if err == nil {
 		t.Errorf("should not be allowed to get empty course")
 	}
+
+	_, err = GetCourses(map[string]interface{}{}, "")
+
+	if err != nil {
+		t.Errorf("should be allowed to query with no qualifiers")
+	}
 }
 
 func TestValidNumber(t *testing.T) {
-	_, err := GetCoursesByNum("ACE", 161, 1)
+	var err error
+	DB, err = gorm.Open(sqlite.Open("../python/course.db"), &gorm.Config{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	_, err = GetCourses(map[string]interface{}{"subject": "ACE", "number": 161}, "LIMIT 1")
 	if err != nil {
 		t.Errorf("error when getting valid course")
 		fmt.Println(err)
 	}
 
-	_, err = GetCoursesByNum("", 225, 1)
+	_, err = GetCourses(map[string]interface{}{"subject": "", "number": 161}, "LIMIT 10")
 
 	if err == nil {
 		t.Errorf("should not be allowed to get empty subject")
 	}
 
-	_, err = GetCoursesByNum("CS", -3, 1)
+	_, err = GetCourses(map[string]interface{}{"subject": "ACE", "number": -3}, "LIMIT 10")
 
 	if err == nil {
 		t.Errorf("should not be allowed to have non-three-digit number (too small)")
 	}
 
-	_, err = GetCoursesByNum("CS", 1000, 1)
+	_, err = GetCourses(map[string]interface{}{"subject": "ACE", "number": 1000}, "LIMIT 10")
 
 	if err == nil {
 		t.Errorf("should not be allowed to have non-three-digit number (too big)")

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -111,8 +111,8 @@ func TestGetCourseByName(t *testing.T) {
 }
 
 func TestGetSections(t *testing.T) {
-	section, err := GetSections(map[string]interface{}{"crn": 10105},"")
-	if (err != nil) {
+	section, err := GetSections(map[string]interface{}{"crn": 10105}, "")
+	if err != nil {
 		t.Errorf("error when getting section")
 	}
 	if section[0].StartDate != "2021-12-20Z" {

--- a/data/db_test.go
+++ b/data/db_test.go
@@ -37,7 +37,7 @@ func TestCourseDataIntegrity(t *testing.T) {
 }
 
 func TestGetCourseByNum(t *testing.T) {
-	course, err := GetCoursesByNum("ACE", 161, 1)
+	course, err := GetCourses(map[string]interface{}{"subject":"ACE", "number":161,}, "LIMIT 1")
 	if err != nil {
 		t.Errorf("error when getting course")
 		fmt.Println(err)
@@ -60,7 +60,7 @@ func TestGetCourseByNum(t *testing.T) {
 }
 
 func TestGetCourseByName(t *testing.T) {
-	course, err := GetCoursesByName("Microcomputer Applications", 1)
+	course, err := GetCourses(map[string]interface{}{"name":"Microcomputer Applications",}, "LIMIT 1")
 	if err != nil {
 		t.Errorf("error when getting course")
 		fmt.Println(err)

--- a/data/db_test.go
+++ b/data/db_test.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -34,50 +33,4 @@ func TestCourseDataIntegrity(t *testing.T) {
 		t.Errorf("incorrect number of columns")
 	}
 	db.Close()
-}
-
-func TestGetCourseByNum(t *testing.T) {
-	course, err := GetCourses(map[string]interface{}{"subject":"ACE", "number":161,}, "LIMIT 1")
-	if err != nil {
-		t.Errorf("error when getting course")
-		fmt.Println(err)
-	}
-	if course[0].Name != "Microcomputer Applications" {
-		t.Errorf("incorrect name")
-	}
-	if course[0].Year != 2022 {
-		t.Errorf("incorrect year")
-	}
-	if course[0].Term != "Winter" {
-		t.Errorf("incorrect term")
-	}
-	if course[0].Subject != "ACE" {
-		t.Errorf("incorrect subject")
-	}
-	if course[0].Number != 161 {
-		t.Errorf("incorrect name")
-	}
-}
-
-func TestGetCourseByName(t *testing.T) {
-	course, err := GetCourses(map[string]interface{}{"name":"Microcomputer Applications",}, "LIMIT 1")
-	if err != nil {
-		t.Errorf("error when getting course")
-		fmt.Println(err)
-	}
-	if course[0].Name != "Microcomputer Applications" {
-		t.Errorf("incorrect name")
-	}
-	if course[0].Year != 2022 {
-		t.Errorf("incorrect year")
-	}
-	if course[0].Term != "Winter" {
-		t.Errorf("incorrect term")
-	}
-	if course[0].Subject != "ACE" {
-		t.Errorf("incorrect subject")
-	}
-	if course[0].Number != 161 {
-		t.Errorf("incorrect name")
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,16 @@ module github.com/CS222-UIUC/course-project-group-10.git
 
 go 1.19
 
-require github.com/mattn/go-sqlite3 v1.14.15
+require (
+	github.com/mattn/go-sqlite3 v1.14.15
+	gorm.io/driver/sqlite v1.4.3
+	gorm.io/gorm v1.24.1
+)
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+)
 
 require (
 	github.com/blockloop/scan v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,11 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
@@ -21,3 +26,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gorm.io/driver/sqlite v1.4.3 h1:HBBcZSDnWi5BW3B3rwvVTc510KGkBkexlOg0QrmLUuU=
+gorm.io/driver/sqlite v1.4.3/go.mod h1:0Aq3iPO+v9ZKbcdiz8gLWRw5VOPcBOPUQJFLq5e2ecI=
+gorm.io/gorm v1.24.0/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
+gorm.io/gorm v1.24.1 h1:CgvzRniUdG67hBAzsxDGOAuq4Te1osVMYsa1eQbd4fs=
+gorm.io/gorm v1.24.1/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=


### PR DESCRIPTION
-getters now take in 2 arguments, a map[string]interface{} that stores column names as keys and values to search for. It will also take in a string with any additional sql statements you want to run before automatically populating your structs
-modified course.go and history.go to use this getter
-created structs for all tables currently in our db
-added a getter for section