### PR TITLE
Add course & instructor IDs to GPA entries & update course db

### DIFF
--- a/python/database_design.md
+++ b/python/database_design.md
@@ -86,9 +86,9 @@ A meeting (i.e. lecture or lab) and an instructor make a class. This is a juncti
 
 | Column Name | Description | Type | Example |
 |-------------|-------------|------|---------|
-| id | Version 4 UUID (Primary key) | INTEGER | e92f76eb-a0a1-459a-b0e4-eef4f6ea7034 |
-| course_id | Primary key of the corresponding course | INTEGER | 9813204 |
-| instructor_id | Primary key of the main instructor | INTEGER | 2825122 |
+| id | Version 4 UUID (Primary key) | TEXT | e92f76eb-a0a1-459a-b0e4-eef4f6ea7034 |
+| course_id | Primary key of the corresponding course | TEXT | ffb094c2-e9b5-450a-88a3-51249195ec63 or None |
+| instructor_id | Primary key of the main instructor | TEXT | bfe81e58-7b97-4675-b713-4000b9a6d978 or None |
 | sched_type | Schedule type | TEXT | LEC |
 | a_plus | Number of students who received an A+ | INTEGER | 8 |
 | a | A | INTEGER | 241 |

--- a/python/db_test.py
+++ b/python/db_test.py
@@ -20,8 +20,7 @@ def test_columns():
     assert len(meetings.columns) == 8
     assert len(instructors.columns) == 3
     assert len(classes.columns) == 2
-    # TODO: when course_id, instructor_id is added to GPA entries in db init, uncomment this test
-    # assert len(gpa_entries.columns) == 18
+    assert len(gpa_entries.columns) == 18
 
     for table in [courses, sections, meetings, instructors, classes]:
         cols = table.columns


### PR DESCRIPTION
course.db contains:
- Fall, Spring, Winter, Summer of 2020
- Fall, Spring, Winter, Summer of 2021
- Fall, Spring, Winter, Summer of 2022
- Spring, Winter of 2023

On another note, I noticed some errors & inconsistencies in the GPA dataset when I added course IDs and instructor IDs to it:
- some GPA entries are linked to a course offering that does not exist in the CIS or Course Explorer. their course_id is set to 'None'. (ex: Winter 2020 ARCH 314).
- some GPA entries' primary instructor field is blank. their instructor_id is set to 'None'. (ex: Fall 2020 FIN 300).
- some GPA entries' primary instructor name is truncated, so it can't be matched with an existing instructor in the Instructor table, even if one exists. their instructor_id is set to 'None'. we can fix this later